### PR TITLE
Grant the sudo group the same login access as the admin group has.

### DIFF
--- a/debian/access.conf.append
+++ b/debian/access.conf.append
@@ -15,6 +15,6 @@
 # on the machine (i.e. are in /etc/passwd).  Allow all other users to
 # login only locally.
 
--:ALL EXCEPT root admin nss-local-users:ALL EXCEPT LOCAL
+-:ALL EXCEPT root sudo admin nss-local-users:ALL EXCEPT LOCAL
 
 #DEBATHENA END


### PR DESCRIPTION
http://askubuntu.com/questions/43317/what-is-the-difference-between-the-sudo-and-admin-group
"Up until Ubuntu 11.10, administrator access using the sudo tool was
granted via the admin Unix group. In Ubuntu 12.04, administrator
access will be granted via the sudo group. This makes Ubuntu more
consistent with the upstream implementation and Debian."
