### PR TITLE
Remove the admin group from the default access.conf

### DIFF
--- a/debian/access.conf.append
+++ b/debian/access.conf.append
@@ -15,6 +15,6 @@
 # on the machine (i.e. are in /etc/passwd).  Allow all other users to
 # login only locally.
 
--:ALL EXCEPT root sudo admin nss-local-users:ALL EXCEPT LOCAL
+-:ALL EXCEPT root sudo nss-local-users:ALL EXCEPT LOCAL
 
 #DEBATHENA END

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+debathena-pam-config (1.27) UNRELEASED; urgency=medium
+
+  * Remove the admin group from the default access.conf, as it is no
+    longer present on Ubuntu either.
+
+ -- Anders Kaseorg <andersk@mit.edu>  Sat, 11 Nov 2017 21:58:08 -0500
+
 debathena-pam-config (1.26) unstable; urgency=medium
 
   [Jacob Morzinski]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,9 @@
-debathena-pam-config (1.27) UNRELEASED; urgency=medium
+debathena-pam-config (1.27) unstable; urgency=medium
 
   * Remove the admin group from the default access.conf, as it is no
     longer present on Ubuntu either.
+  * Check at build time that users and groups in the default access.conf
+    exist.
 
  -- Anders Kaseorg <andersk@mit.edu>  Sat, 11 Nov 2017 21:58:08 -0500
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: debathena-pam-config
 Section: debathena-config/net
 Priority: extra
 Maintainer: Debathena Project <debathena@mit.edu>
-Build-Depends: cdbs, debhelper, config-package-dev (>= 5.0~), libpam-runtime, gdm3 | gdm, openssh-server (>= 1:4.3) | ssh-krb5, lsb-release
+Build-Depends: cdbs, debhelper, config-package-dev (>= 5.0~), libpam-runtime, gdm3 | gdm, openssh-server (>= 1:4.3) | ssh-krb5
 Standards-Version: 3.9.3
 
 Package: debathena-pam-config

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: debathena-pam-config
 Section: debathena-config/net
 Priority: extra
 Maintainer: Debathena Project <debathena@mit.edu>
-Build-Depends: cdbs, debhelper, config-package-dev (>= 5.0~), libpam-runtime, gdm3 | gdm, openssh-server (>= 1:4.3) | ssh-krb5
+Build-Depends: cdbs, debhelper, config-package-dev (>= 5.0~), libpam-runtime, gdm3 | gdm, openssh-server (>= 1:4.3) | ssh-krb5, base-passwd
 Standards-Version: 3.9.3
 
 Package: debathena-pam-config

--- a/debian/rules
+++ b/debian/rules
@@ -96,6 +96,12 @@ endif
 common-build-indep:: debian/access.conf.debathena
 
 debian/access.conf.debathena: $(call debian_check_files,/etc/security/access.conf)
+	set -eux; for user in $$(awk -F: '/^[^#]/ {print $$2}' debian/access.conf.append); do \
+	    case "$$user" in \
+	        ALL|EXCEPT|nss-local-users) ;; \
+	        *) cut -d: -f1 /usr/share/base-passwd/passwd.master /usr/share/base-passwd/group.master | grep -Fxe "$$user";; \
+	    esac; \
+	done
 	cat $< debian/access.conf.append > $@
 
 clean::

--- a/debian/rules
+++ b/debian/rules
@@ -95,17 +95,8 @@ endif
 
 common-build-indep:: debian/access.conf.debathena
 
-LSB_ID = $(shell lsb_release --short --id)
 debian/access.conf.debathena: $(call debian_check_files,/etc/security/access.conf)
-ifeq ($(LSB_ID), Debian)
-	(cat $<; sed 's/root admin /root /' debian/access.conf.append) > $@
-else
-    ifeq ($(LSB_ID), Ubuntu)
 	cat $< debian/access.conf.append > $@
-    else
-	$(error Unrecognized distribution ID $(LSB_ID).)
-    endif
-endif
 
 clean::
 	rm -f debian/access.conf.debathena


### PR DESCRIPTION
Addresses a regression introduced by #2 where the `admin` group was no longer being removed on Debian; we now remove it on Ubuntu as well because it no longer exists. Also, add a build time check that the groups still mentioned do exist.